### PR TITLE
V1.0.2 Bump Octokit to 3.0.0 and query 100 PR files per page

### DIFF
--- a/CodeOwnersParser.sln
+++ b/CodeOwnersParser.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31402.337
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeOwnersParser", "CodeOwnersParser\CodeOwnersParser.csproj", "{0498B1C2-6A6F-44CA-A484-82158D812FFA}"
 EndProject

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Octokit" Version="2.0.1" />
+    <PackageReference Include="Octokit" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/CodeOwnersParser/Helpers.cs
+++ b/CodeOwnersParser/Helpers.cs
@@ -101,10 +101,6 @@ namespace CodeOwnersParser
             string regexString = "";
             //String containing the prepared path (escapeing, replacing etc.). Used so path doesn't get modified because its used as key
             string preparedPath;
-            //Entry ends with / aka only mathches folders not files
-            bool folderOnly = false;
-            //No slash at the beginning or middle, can match at any depth
-            bool anyDepth = false;
             //No slashes at all, match any file at any level
             bool fileMode = false;
 
@@ -114,10 +110,6 @@ namespace CodeOwnersParser
                 return regexString;
             }
 
-            if (path.EndsWith("/"))
-                folderOnly = true;
-            if (path[0..(path.Length - 1)].Contains("/"))
-                anyDepth = true;
             if (!path.Contains("/"))
                 fileMode = true;
 

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -36,7 +36,11 @@ static void NotifyOwners(ActionInputs inputs)
     }
 
     Console.WriteLine($"Getting PR files for PR with ID {inputs.pullID}");
-    var modifiedFilesTask = ghclient.PullRequest.Files(inputs.Owner, inputs.Name, inputs.pullID);
+    var batchPagination = new ApiOptions
+    {
+        PageSize = 100
+    };
+    var modifiedFilesTask = ghclient.PullRequest.Files(inputs.Owner, inputs.Name, inputs.pullID, batchPagination);
     List<Octokit.PullRequestFile> modifiedFiles;
     if (modifiedFilesTask.Wait(inputs.timeout))
     {


### PR DESCRIPTION
Bumps Octokit to 3.0.0 which now allows passing APIOptions to PullRequest.Files.
This allows querying 100 files per page which should decrease API usage but to 3x for very large PRs.

Also removes some unused vars that where never needed for Regex generation.