### PR TITLE
V1.0.3 Octokit bump, Better parameter description and new GITHUB_OUTPUT

### DIFF
--- a/CodeOwnersParser.sln
+++ b/CodeOwnersParser.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Dockerfile = Dockerfile
 		example-assign-workflow.yml = example-assign-workflow.yml
 		example-comment-workflow.yml = example-comment-workflow.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/CodeOwnersParser/ActionInputs.cs
+++ b/CodeOwnersParser/ActionInputs.cs
@@ -34,24 +34,24 @@ namespace CodeOwnersParser
 
         [Option('t', "timeout",
             Required = false,
-            HelpText = "The workspace directory, or repository root directory. Use `/github/workspace`.",
+            HelpText = "Timeout for Github API calls in milliseconds.",
             Default = 10000)]
         public int timeout { get; set; } = 0;
 
         [Option('l', "fileLimit",
             Required = false,
-            HelpText = "The workspace directory, or repository root directory. Use `/github/workspace`.",
+            HelpText = "Maximum amount of files to process. PRs with more files will be skipped.",
             Default = 1000)]
         public int fileLimit { get; set; } = 0;
 
         [Option('k', "token",
             Required = false,
-            HelpText = "The workspace directory, or repository root directory. Use `/github/workspace`.")]
+            HelpText = "Token used for Github API calls.")]
         public string token { get; set; } = null!;
 
         [Option('f', "file",
             Required = false,
-            HelpText = "Path to the codeowners file.",
+            HelpText = "Relative path to the codeowners file.",
             Default = "/.github/CODEOWNERS")]
         public string file { get; set; } = null!;
 

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -6,7 +6,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AssemblyName>CodeOwnersParser</AssemblyName>
     <RootNamespace>CodeOwnersParser</RootNamespace>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CodeOwnersParser/CodeOwnersParser.csproj
+++ b/CodeOwnersParser/CodeOwnersParser.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Octokit" Version="3.0.0" />
+    <PackageReference Include="Octokit" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -73,8 +73,9 @@ static void NotifyOwners(ActionInputs inputs)
     string output = String.Join(inputs.separator, ownersWithModifiedFiles);
 
     Console.WriteLine($"Owners with file changes: {output}");
-    Console.WriteLine($"::set-output name=owners::{output}");
+    Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners={output}");
     Console.WriteLine($"Output: {inputs.prefix + output + inputs.sufix}");
-    Console.WriteLine($"::set-output name=owners-formatted::{inputs.prefix + output + inputs.sufix}");
+    Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners-formatted={inputs.prefix + output + inputs.sufix}");
+
 }
 

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -76,6 +76,6 @@ static void NotifyOwners(ActionInputs inputs)
     Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners={output}");
     Console.WriteLine($"Output: {inputs.prefix + output + inputs.sufix}");
     Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners-formatted={inputs.prefix + output + inputs.sufix}");
-
+    Console.WriteLine("GITHUB_OUTPUT content: " + Environment.GetEnvironmentVariable("GITHUB_OUTPUT"));
 }
 

--- a/CodeOwnersParser/Program.cs
+++ b/CodeOwnersParser/Program.cs
@@ -5,7 +5,7 @@ using static CommandLine.Parser;
 using CodeOwnersParser;
 using System.Collections.Generic;
 using Octokit;
-using System.Threading.Tasks;
+using System.IO;
 
 var parser = Default.ParseArguments<ActionInputs>(() => new(), args);
 parser.WithNotParsed(
@@ -70,12 +70,10 @@ static void NotifyOwners(ActionInputs inputs)
         ownersWithModifiedFiles = ownersWithModifiedFiles.Except(notifiedOwners).ToList();
     }
 
-    string output = String.Join(inputs.separator, ownersWithModifiedFiles);
-
-    Console.WriteLine($"Owners with file changes: {output}");
-    Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners={output}");
-    Console.WriteLine($"Output: {inputs.prefix + output + inputs.sufix}");
-    Environment.SetEnvironmentVariable("GITHUB_OUTPUT", Environment.GetEnvironmentVariable("GITHUB_OUTPUT") + "\n" + $"owners-formatted={inputs.prefix + output + inputs.sufix}");
-    Console.WriteLine("GITHUB_OUTPUT content: " + Environment.GetEnvironmentVariable("GITHUB_OUTPUT"));
+    string owners = String.Join(inputs.separator, ownersWithModifiedFiles);
+    string[] output = { $"owners={owners}", $"owners-formatted={inputs.prefix + owners + inputs.sufix}"};
+    Console.WriteLine($"Owners: {output[0]}");
+    Console.WriteLine($"Owners-formatted: {output[1]}");
+    File.WriteAllLines(Environment.GetEnvironmentVariable("GITHUB_OUTPUT"), output);
 }
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Name | Required | Default | Description
 ------------ | ------------- | ------------- | -------------
 owner | no | github.repository_owner | Name of repo owner
 name | no | github.repository | Name of the repo
-timeout | no | '10000' | Timeout for Github REST API calls
-fileLimit | no | '1000' | Maximum amount of file a PR might have, if exceeded it won't be processed and the action will fail. Setting this to a high value might result in rate limiting.
-token | no | github.token | Token used for REST calls. Only needed to increase rate limits, can be replaced with empty string, but might lead to rate limit errors.
+timeout | no | '10000' | Timeout for Github API calls in milliseconds.
+fileLimit | no | '1000' | Maximum amount of file a PR might have, if exceeded it won't be processed. Setting this to a high value might result in rate limiting.
+token | no | github.token | Token used for Github API calls. Only needed to increase rate limits, can be replaced with empty string, but might lead to rate limit errors.
 workspace | no | '/github/workspace' | Location of the repo in the workflow. Normally '/github/workspace' for Docker workflows.
 file | no | '/.github/CODEOWNERS' | Relative location of the CODEOWNERS file in the repo. Useful if you want a separate owner file for this action.
 pullID | no | github.event.pull_request.number | ID of the PR to get modified files from

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ${{ github.repository }}
   timeout:
     description:
-      "Timeout for Github REST API requests."
+      "Timeout for Github API requests in milliseconds."
     required: false
     default: '10000'
   fileLimit:
@@ -26,7 +26,7 @@ inputs:
     default: '1000'
   token:
     description:
-      "Github token used for REST API. Only needed to increase rate limit, may not be provided."
+      "Github token used for Github API. Only needed to increase rate limit, may not be provided."
     required: false
     default: ${{ github.token }}
   workspace:


### PR DESCRIPTION
-Bumps Octokit to 4.0.1
-Changes some descriptions for inputs
-Use the new GITHUB_OUTPUT system instead of set-output